### PR TITLE
Add library publishing and update Gradle/Kotlin versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ Optional parameters:
 * `-f` to force overwrite target `_nonstop.svg` file, 
 * `-v` to have verbose output.
 
+## Using as a Java/Kotlin dependency
+
+From version 1.1.2, SVG non-stop is available via [JitPack](https://jitpack.io/#14v/svg-non-stop) as a library:
+
+```groovy
+repositories {
+   // ...
+   maven { url 'https://jitpack.io' }
+}
+dependencies {
+   implementation "com.github.14v:svg-non-stop:$version"
+}
+```
+
+Use `NonStop.process(rootNodes)` with the root [NodeList](https://docs.oracle.com/javase/8/docs/api/org/w3c/dom/NodeList.html)
+of the SVG file. See the source of the `main()` function for an example.
+
 ## Technical notes
 Utility copies stops definitions into target gradients in SVG file. Then IDE can process file correctly. Utility is _not_ for use in android code.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ group = "com.github.14v"
 version = "1.1.2"
 
 application {
-    mainClass.set("NonStopKt")
+    mainClass.set("com.github.fourteenv.NonStopKt")
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,15 @@
 plugins {
-    kotlin("jvm") version "1.3.61"
+    kotlin("jvm") version "1.6.10"
     application
+    `java-library`
+    `maven-publish`
 }
 
-group = ""
-version = "1.1.1"
+group = "com.github.14v"
+version = "1.1.2"
 
 application {
-    mainClassName = "NonStopKt"
+    mainClass.set("NonStopKt")
 }
 
 repositories {
@@ -24,5 +26,31 @@ tasks {
     }
     compileTestKotlin {
         kotlinOptions.jvmTarget = "1.8"
+    }
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+
+            pom {
+                name.set("svg-non-stop")
+                url.set("https://github.com/14v/svg-non-stop")
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://github.com/14v/svg-non-stop/blob/master/LICENSE")
+                    }
+                }
+            }
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
     `maven-publish`
 }
 
-group = "com.github.14v"
+group = "io.github.14v"
 version = "1.1.2"
 
 application {
-    mainClass.set("com.github.fourteenv.NonStopKt")
+    mainClass.set("io.github.fourteenv.NonStopKt")
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/NonStop.kt
+++ b/src/main/kotlin/NonStop.kt
@@ -1,4 +1,4 @@
-package com.github.fourteenv
+package io.github.fourteenv
 
 import org.w3c.dom.NamedNodeMap
 import org.w3c.dom.Node

--- a/src/main/kotlin/NonStop.kt
+++ b/src/main/kotlin/NonStop.kt
@@ -8,10 +8,22 @@ import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
 
+/**
+ * Utility for repairing SVG for compatibility with Android build tools vector drawable
+ * conversion.
+ */
 object NonStop {
 
+    /**
+     * Whether to log verbosely when processing.
+     */
     var optionVerbose = false
 
+    /**
+     * Modifies the given XML [rootNodes] to repair missing stop info so the SVG can be
+     * converted to an Android vector asset by the Android build tools.
+     * @return whether any changes were made.
+     */
     fun processSvg(rootNodes: NodeList): Boolean {
         val defsNode = rootNodes.findNode("defs")
         if (defsNode == null) {

--- a/src/main/kotlin/NonStop.kt
+++ b/src/main/kotlin/NonStop.kt
@@ -1,3 +1,5 @@
+package com.github.fourteenv
+
 import org.w3c.dom.NamedNodeMap
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
@@ -17,6 +19,7 @@ object NonStop {
     /**
      * Whether to log verbosely when processing.
      */
+    @JvmStatic
     var optionVerbose = false
 
     /**
@@ -24,6 +27,7 @@ object NonStop {
      * converted to an Android vector asset by the Android build tools.
      * @return whether any changes were made.
      */
+    @JvmStatic
     fun processSvg(rootNodes: NodeList): Boolean {
         val defsNode = rootNodes.findNode("defs")
         if (defsNode == null) {


### PR DESCRIPTION
This will allow SVG non-stop to be used as a project dependency via JitPack as explained in the updated README. It will take effect after tagging the pulled commit with "1.1.2" and then opening [this Jitpack link](https://jitpack.io/#14v/svg-non-stop/1.1.2) to give JitPack a chance to build and publish it.

I tested Gradle `assemble` and the built application to confirm none of the Gradle changes affect current use of the app.

I updated the Gradle and Kotlin versions to help future-proof it.